### PR TITLE
Upgrade Checker - Design PR

### DIFF
--- a/x-pack/plugins/upgrade_checkup/public/_app.scss
+++ b/x-pack/plugins/upgrade_checkup/public/_app.scss
@@ -1,0 +1,4 @@
+upgrade-checkup {
+  flex-grow: 1;
+  background-color: $euiColorLightestShade;
+}

--- a/x-pack/plugins/upgrade_checkup/public/app.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/app.tsx
@@ -6,22 +6,14 @@
 
 import React from 'react';
 
-import {
-  EuiPage,
-  EuiPageBody,
-  EuiPageContent,
-  EuiPageContentBody,
-  EuiPageHeader,
-  EuiPageHeaderSection,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiPage, EuiPageBody, EuiPageHeader, EuiPageHeaderSection, EuiTitle } from '@elastic/eui';
 
 import { UpgradeCheckupTabs } from './components/tabs';
 
 export class RootComponent extends React.Component {
   public render() {
     return (
-      <EuiPage>
+      <EuiPage restrictWidth>
         <EuiPageBody>
           <EuiPageHeader>
             <EuiPageHeaderSection>
@@ -30,11 +22,7 @@ export class RootComponent extends React.Component {
               </EuiTitle>
             </EuiPageHeaderSection>
           </EuiPageHeader>
-          <EuiPageContent>
-            <EuiPageContentBody>
-              <UpgradeCheckupTabs />
-            </EuiPageContentBody>
-          </EuiPageContent>
+          <UpgradeCheckupTabs />
         </EuiPageBody>
       </EuiPage>
     );

--- a/x-pack/plugins/upgrade_checkup/public/components/_index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/_index.scss
@@ -1,0 +1,1 @@
+@import './tabs/checkup/index';

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_cell.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_cell.scss
@@ -1,0 +1,3 @@
+.upgCell {
+  overflow: hidden;
+}

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_cell.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_cell.scss
@@ -1,3 +1,4 @@
-.upgCell {
+.upgDeprecationCell {
   overflow: hidden;
+  padding: $euiSizeL 0 0 $euiSizeL;
 }

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_cell.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_cell.scss
@@ -1,4 +1,4 @@
 .upgDeprecationCell {
   overflow: hidden;
-  padding: $euiSizeL 0 0 $euiSizeL;
+  padding: $euiSize 0 0 $euiSizeL;
 }

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_deprecations.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_deprecations.scss
@@ -1,0 +1,18 @@
+.upgDeprecations {
+  // Pull the container through the padding of EuiPageContent
+  margin-left: -$euiSizeL;
+  margin-right: -$euiSizeL;
+}
+
+.upgDeprecations__item {
+  padding: $euiSizeL;
+  border-top: $euiBorderThin;
+
+  &:last-of-type {
+    margin-bottom: -$euiSizeL;
+  }
+}
+
+.upgDeprecations__itemName {
+  font-weight: $euiFontWeightMedium;
+}

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_deprecations.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_deprecations.scss
@@ -5,7 +5,7 @@
 }
 
 .upgDeprecations__item {
-  padding: $euiSizeL;
+  padding: $euiSize $euiSizeL;
   border-top: $euiBorderThin;
 
   &:last-of-type {

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_index.scss
@@ -1,0 +1,1 @@
+@import './deprecations';

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/_index.scss
@@ -1,1 +1,2 @@
+@import './cell';
 @import './deprecations';

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
@@ -29,7 +29,7 @@ export const DeprecationCell: StatelessComponent<DeprecationCellProps> = ({
   items,
   children,
 }) => (
-  <div className="upgrade-checkup__deprecation-cell">
+  <div className="upgCell">
     <EuiFlexGroup alignItems="center">
       <EuiFlexItem grow>
         {headline && (

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
@@ -6,12 +6,12 @@
 
 import React, { ReactNode, StatelessComponent } from 'react';
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiTitle } from '@elastic/eui';
 
 interface DeprecationCellProps {
   headline?: string;
   healthColor?: string;
-  uiButtons: Array<{
+  uiButtons?: Array<{
     label: string;
     url: string;
   }>;
@@ -29,41 +29,41 @@ export const DeprecationCell: StatelessComponent<DeprecationCellProps> = ({
   items,
   children,
 }) => (
-  <div className="upgCell">
-    <EuiFlexGroup alignItems="center">
+  <div className="upgDeprecationCell">
+    <EuiFlexGroup responsive={false} wrap alignItems="baseline">
+      {healthColor && (
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="dot" color={healthColor} />
+        </EuiFlexItem>
+      )}
+
       <EuiFlexItem grow>
         {headline && (
-          <EuiText>
-            <h4>
-              {healthColor && <EuiIcon type="dot" color={healthColor} />} {headline}
-            </h4>
-          </EuiText>
+          <EuiTitle size="xxs">
+            <h2>{headline}</h2>
+          </EuiTitle>
         )}
+
+        {items.map(item => (
+          <div key={item.title}>
+            <EuiText>
+              {item.title && <h6>{item.title}</h6>}
+              <p>{item.body}</p>
+            </EuiText>
+          </div>
+        ))}
       </EuiFlexItem>
-      {uiButtons.map(button => (
-        <EuiFlexItem key={button.url} grow={false}>
-          <EuiButton size="s" href={button.url} target="_blank">
-            {button.label}
-          </EuiButton>
-        </EuiFlexItem>
-      ))}
+
+      {uiButtons &&
+        uiButtons.map(button => (
+          <EuiFlexItem key={button.url} grow={false}>
+            <EuiButton size="s" href={button.url} target="_blank">
+              {button.label}
+            </EuiButton>
+          </EuiFlexItem>
+        ))}
     </EuiFlexGroup>
 
-    {items.map(item => (
-      <div key={item.title}>
-        <EuiSpacer size="m" />
-        <EuiText>
-          {item.title && <h6>{item.title}</h6>}
-          <p>{item.body}</p>
-        </EuiText>
-      </div>
-    ))}
-
-    {children && (
-      <div>
-        <EuiSpacer size="m" />
-        {children}
-      </div>
-    )}
+    {children}
   </div>
 );

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
@@ -29,7 +29,7 @@ export const DeprecationCell: StatelessComponent<DeprecationCellProps> = ({
   items,
   children,
 }) => (
-  <EuiFlexItem className="upgrade-checkup__deprecation-cell">
+  <div className="upgrade-checkup__deprecation-cell">
     <EuiFlexGroup alignItems="center">
       <EuiFlexItem grow>
         {headline && (
@@ -65,5 +65,5 @@ export const DeprecationCell: StatelessComponent<DeprecationCellProps> = ({
         {children}
       </div>
     )}
-  </EuiFlexItem>
+  </div>
 );

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/cell.tsx
@@ -6,7 +6,16 @@
 
 import React, { ReactNode, StatelessComponent } from 'react';
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 
 interface DeprecationCellProps {
   headline?: string;
@@ -43,6 +52,11 @@ export const DeprecationCell: StatelessComponent<DeprecationCellProps> = ({
             <h2>{headline}</h2>
           </EuiTitle>
         )}
+
+        <div>
+          <EuiLink>Documentation link here</EuiLink>
+          <EuiSpacer size="s" />
+        </div>
 
         {items.map(item => (
           <div key={item.title}>

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/checkup_tab.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/checkup_tab.tsx
@@ -11,9 +11,10 @@ import {
   // @ts-ignore
   EuiAccordion,
   EuiCallOut,
+  EuiPageContent,
+  EuiPageContentBody,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 
 import chrome from 'ui/chrome';
@@ -67,30 +68,30 @@ export class CheckupTab extends React.Component<CheckupTabProps, CheckupTabState
     return (
       <Fragment>
         <EuiSpacer />
-        <EuiTitle>
-          <h3 style={{ textTransform: 'capitalize' }}>{checkupType} Checkup</h3>
-        </EuiTitle>
-        <EuiSpacer />
-        <EuiText>
+        <EuiText grow={false}>
           <p>
-            This tool runs a series of checks against your Elasticsearch {checkupType} to determine
-            whether you can upgrade directly to Elasticsearch 7.0, or whether you need to make
-            changes to your data before doing so.
+            This tool runs a series of checks against your Elasticsearch{' '}
+            <strong>{checkupType}</strong> to determine whether you can upgrade directly to
+            Elasticsearch 7.0, or whether you need to make changes to your data before doing so.
           </p>
         </EuiText>
         <EuiSpacer />
-        <CheckupControls
-          allDeprecations={deprecations}
-          loadingState={loadingState}
-          loadData={this.loadData}
-          currentFilter={currentFilter}
-          onFilterChange={this.changeFilter}
-          availableGroupByOptions={this.availableGroupByOptions()}
-          currentGroupBy={currentGroupBy}
-          onGroupByChange={this.changeGroupBy}
-        />
-        <EuiSpacer />
-        {this.renderCheckupData()}
+        <EuiPageContent>
+          <EuiPageContentBody>
+            <CheckupControls
+              allDeprecations={deprecations}
+              loadingState={loadingState}
+              loadData={this.loadData}
+              currentFilter={currentFilter}
+              onFilterChange={this.changeFilter}
+              availableGroupByOptions={this.availableGroupByOptions()}
+              currentGroupBy={currentGroupBy}
+              onGroupByChange={this.changeGroupBy}
+            />
+            <EuiSpacer />
+            {this.renderCheckupData()}
+          </EuiPageContentBody>
+        </EuiPageContent>
       </Fragment>
     );
   }

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/checkup_tab.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/checkup_tab.tsx
@@ -149,13 +149,11 @@ export class CheckupTab extends React.Component<CheckupTabProps, CheckupTabState
     }
 
     return (
-      <div>
-        <GroupedDeprecations
-          currentGroupBy={currentGroupBy}
-          currentFilter={currentFilter}
-          allDeprecations={deprecations}
-        />
-      </div>
+      <GroupedDeprecations
+        currentGroupBy={currentGroupBy}
+        currentFilter={currentFilter}
+        allDeprecations={deprecations}
+      />
     );
   }
 }

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/controls.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/controls.tsx
@@ -44,11 +44,12 @@ export const CheckupControls: StatelessComponent<CheckupControlsProps> = ({
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <EuiButton
+        fill
         onClick={loadData}
         iconType="refresh"
         isLoading={loadingState === LoadingState.Loading}
       >
-        {loadingState === LoadingState.Loading ? 'Loading…' : 'Refresh'}
+        Refresh
       </EuiButton>
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/controls.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/controls.tsx
@@ -5,7 +5,7 @@
  */
 import React, { StatelessComponent } from 'react';
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButton, EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { DeprecationInfo } from 'src/core_plugins/elasticsearch';
 import { LevelFilterBar } from './filter_bar';
 import { GroupByBar } from './group_by_bar';
@@ -33,10 +33,12 @@ export const CheckupControls: StatelessComponent<CheckupControlsProps> = ({
   onGroupByChange,
 }) => (
   <EuiFlexGroup alignItems="center" wrap={true} responsive={false}>
+    <EuiFlexItem grow={true}>
+      <EuiFieldSearch placeholder="Filter list" />
+    </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <LevelFilterBar {...{ allDeprecations, currentFilter, onFilterChange }} />
     </EuiFlexItem>
-    <EuiFlexItem />
     <EuiFlexItem grow={false}>
       <GroupByBar {...{ availableGroupByOptions, currentGroupBy, onGroupByChange }} />
     </EuiFlexItem>

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/controls.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/controls.tsx
@@ -32,23 +32,22 @@ export const CheckupControls: StatelessComponent<CheckupControlsProps> = ({
   currentGroupBy,
   onGroupByChange,
 }) => (
-  <EuiFlexGroup alignItems="center">
-    <EuiFlexItem grow>
-      <div>
-        <EuiButton
-          onClick={loadData}
-          iconType="refresh"
-          isLoading={loadingState === LoadingState.Loading}
-        >
-          {loadingState === LoadingState.Loading ? 'Loading…' : 'Rerun Checkup'}
-        </EuiButton>
-      </div>
+  <EuiFlexGroup alignItems="center" wrap={true} responsive={false}>
+    <EuiFlexItem grow={false}>
+      <LevelFilterBar {...{ allDeprecations, currentFilter, onFilterChange }} />
     </EuiFlexItem>
+    <EuiFlexItem />
     <EuiFlexItem grow={false}>
       <GroupByBar {...{ availableGroupByOptions, currentGroupBy, onGroupByChange }} />
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <LevelFilterBar {...{ allDeprecations, currentFilter, onFilterChange }} />
+      <EuiButton
+        onClick={loadData}
+        iconType="refresh"
+        isLoading={loadingState === LoadingState.Loading}
+      >
+        {loadingState === LoadingState.Loading ? 'Loading…' : 'Refresh'}
+      </EuiButton>
     </EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
@@ -137,9 +137,20 @@ export const GroupedDeprecations: StatelessComponent<GroupedDeprecationsProps> =
 
   return (
     <div>
-      <EuiText size="s">
-        <p>{message}</p>
-      </EuiText>
+      <EuiFlexGroup responsive={false} alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty size="s">Expand all</EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty size="s">Collapse all</EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem />
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <p>{message}</p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
       <EuiSpacer size="s" />
 

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
@@ -219,7 +219,8 @@ export const GroupedDeprecations: StatelessComponent<GroupedDeprecationsProps> =
                   {currentGroupBy === GroupByOption.message && (
                     <Fragment>
                       &emsp;
-                      <EuiButton size="s">Move button here</EuiButton>
+                      {/* TODO: This button should be the action-oriented version if it exists */}
+                      <EuiButton size="s">Action button here</EuiButton>
                     </Fragment>
                   )}
                 </div>

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
@@ -32,11 +32,6 @@ const MessageDeprecation: StatelessComponent<{ deprecation: EnrichedDeprecationI
 }) => {
   const items = [];
 
-  const action = ACTION_MAP[deprecation.level];
-  if (action) {
-    items.push({ body: action });
-  }
-
   if (deprecation.details) {
     items.push({ title: 'Details', body: deprecation.details });
   }
@@ -71,11 +66,6 @@ interface IndexDeprecationProps {
  */
 const IndexDeprecation: StatelessComponent<IndexDeprecationProps> = ({ deprecation, indices }) => {
   const items = [];
-
-  const action = ACTION_MAP[deprecation.level];
-  if (action) {
-    items.push({ body: action });
-  }
 
   // Only show the last uiButton which should be the documentation link.
   const uiButtons = [deprecation.uiButtons[deprecation.uiButtons.length - 1]];
@@ -167,7 +157,6 @@ export const GroupedDeprecations: StatelessComponent<GroupedDeprecationsProps> =
               <EuiSpacer />
               <DeprecationList deprecations={groups[groupName]} currentGroupBy={currentGroupBy} />
             </EuiAccordion>,
-            // <EuiSpacer key={`spc-${groupName}`} />,
           ])}
       </div>
     </div>

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
@@ -11,7 +11,7 @@ import { EuiAccordion, EuiSpacer, EuiText } from '@elastic/eui';
 import { DeprecationInfo } from 'src/core_plugins/elasticsearch';
 import { EnrichedDeprecationInfo } from '../../../../server/lib/es_migration_apis';
 import { DeprecationCell } from './cell';
-import { ACTION_MAP, COLOR_MAP, LEVEL_MAP } from './constants';
+import { COLOR_MAP, LEVEL_MAP } from './constants';
 import { DeprecationHealth } from './health';
 import { IndexDeprecationDetails, IndexDeprecationTable } from './index_table';
 import { GroupByOption, LevelFilterOption } from './types';
@@ -33,7 +33,7 @@ const MessageDeprecation: StatelessComponent<{ deprecation: EnrichedDeprecationI
   const items = [];
 
   if (deprecation.details) {
-    items.push({ title: 'Details', body: deprecation.details });
+    items.push({ body: deprecation.details });
   }
 
   return (

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/deprecations.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { StatelessComponent } from 'react';
+import React, { Fragment, StatelessComponent } from 'react';
 
 import { EuiAccordion, EuiSpacer, EuiText } from '@elastic/eui';
 
@@ -135,38 +135,41 @@ export const GroupedDeprecations: StatelessComponent<GroupedDeprecationsProps> =
 }) => {
   const deprecations = allDeprecations.filter(filterDeps(currentFilter));
 
-  // Display some text if no deprecations are going to be shown.
-  if (deprecations.length === 0) {
-    const message =
-      allDeprecations.length === 0
-        ? `No deprecations.`
-        : `0 of ${allDeprecations.length} shown. Change filters to see more.`;
+  // Display number of results shown
+  const showMoreMessage = deprecations.length === 0 ? '. Change filters to show more.' : '';
 
-    return (
-      <EuiText color="subdued">
-        <p>{message}</p>
-      </EuiText>
-    );
-  }
+  const message =
+    allDeprecations.length === 0
+      ? `No deprecations`
+      : `Showing ${deprecations.length} of ${allDeprecations.length}${showMoreMessage}`;
 
   const groups = _.groupBy(deprecations, currentGroupBy);
 
   return (
     <div>
-      {Object.keys(groups)
-        .sort()
-        .map(groupName => [
-          <EuiAccordion
-            key={`acc-${groupName}`}
-            id={`depgroup-${groupName}`}
-            buttonContent={groupName}
-            extraAction={<DeprecationHealth deprecations={groups[groupName]} />}
-          >
-            <EuiSpacer />
-            <DeprecationList deprecations={groups[groupName]} currentGroupBy={currentGroupBy} />
-          </EuiAccordion>,
-          <EuiSpacer key={`spc-${groupName}`} />,
-        ])}
+      <EuiText size="s">
+        <p>{message}</p>
+      </EuiText>
+
+      <EuiSpacer size="s" />
+
+      <div className="upgDeprecations">
+        {Object.keys(groups)
+          .sort()
+          .map(groupName => [
+            <EuiAccordion
+              className="upgDeprecations__item"
+              key={`acc-${groupName}`}
+              id={`depgroup-${groupName}`}
+              buttonContent={<span className="upgDeprecations__itemName">{groupName}</span>}
+              extraAction={<DeprecationHealth deprecations={groups[groupName]} />}
+            >
+              <EuiSpacer />
+              <DeprecationList deprecations={groups[groupName]} currentGroupBy={currentGroupBy} />
+            </EuiAccordion>,
+            // <EuiSpacer key={`spc-${groupName}`} />,
+          ])}
+      </div>
     </div>
   );
 };

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/filter_bar.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/filter_bar.tsx
@@ -12,11 +12,8 @@ import {
   EuiFilterButton,
   // @ts-ignore
   EuiFilterGroup,
-  EuiFlexGroup,
-  EuiFlexItem,
   // @ts-ignore
   EuiNotificationBadge,
-  EuiText,
 } from '@elastic/eui';
 import { DeprecationInfo } from 'src/core_plugins/elasticsearch';
 import { LevelFilterOption } from './types';
@@ -43,25 +40,18 @@ export class LevelFilterBar extends React.Component<LevelFilterBarProps> {
     );
 
     return (
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem>
-          <EuiText color="subdued">Level</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiFilterGroup>
-            {allFilterOptions.map(option => (
-              <EuiFilterButton
-                key={option}
-                onClick={this.filterClicked.bind(this, option)}
-                hasActiveFilters={currentFilter.has(option)}
-                numFilters={levelCounts[option] || undefined}
-              >
-                {option}
-              </EuiFilterButton>
-            ))}
-          </EuiFilterGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFilterGroup>
+        {allFilterOptions.map(option => (
+          <EuiFilterButton
+            key={option}
+            onClick={this.filterClicked.bind(this, option)}
+            hasActiveFilters={currentFilter.has(option)}
+            numFilters={levelCounts[option] || undefined}
+          >
+            {option}
+          </EuiFilterButton>
+        ))}
+      </EuiFilterGroup>
     );
   }
 

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/group_by_bar.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/group_by_bar.tsx
@@ -11,17 +11,14 @@ import {
   EuiFilterButton,
   // @ts-ignore
   EuiFilterGroup,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
 } from '@elastic/eui';
 import { GroupByOption } from './types';
 
 // UI labels for the enum type
 const GroupByOptionLabel: { [I in GroupByOption]: string } = {
-  [GroupByOption.message]: 'issue',
-  [GroupByOption.index]: 'index',
-  [GroupByOption.node]: 'node',
+  [GroupByOption.message]: 'by issue',
+  [GroupByOption.index]: 'by index',
+  [GroupByOption.node]: 'by node',
 };
 
 interface GroupByBarProps {
@@ -39,24 +36,17 @@ export class GroupByBar extends React.Component<GroupByBarProps> {
     }
 
     return (
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem>
-          <EuiText color="subdued">Group By</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiFilterGroup>
-            {availableGroupByOptions.map(option => (
-              <EuiFilterButton
-                key={option}
-                onClick={this.filterClicked.bind(this, option)}
-                hasActiveFilters={currentGroupBy === option}
-              >
-                {GroupByOptionLabel[option]}
-              </EuiFilterButton>
-            ))}
-          </EuiFilterGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFilterGroup>
+        {availableGroupByOptions.map(option => (
+          <EuiFilterButton
+            key={option}
+            onClick={this.filterClicked.bind(this, option)}
+            hasActiveFilters={currentGroupBy === option}
+          >
+            {GroupByOptionLabel[option]}
+          </EuiFilterButton>
+        ))}
+      </EuiFilterGroup>
     );
   }
 

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/health.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/health.tsx
@@ -13,13 +13,18 @@ import { ACTION_MAP, COLOR_MAP, LEVEL_MAP, REVERSE_LEVEL_MAP } from './constants
 
 interface DeprecationHealthProps {
   deprecations: DeprecationInfo[];
+  single?: boolean;
 }
 
 /**
  * Displays a summary health for a list of deprecations that shows the number and level of highest severity
  * deprecations in the list.
+ * TODO: Allow showing all severity levels
  */
-export const DeprecationHealth: StatelessComponent<DeprecationHealthProps> = ({ deprecations }) => {
+export const DeprecationHealth: StatelessComponent<DeprecationHealthProps> = ({
+  deprecations,
+  single,
+}) => {
   if (deprecations.length === 0) {
     return <span />;
   }
@@ -33,7 +38,7 @@ export const DeprecationHealth: StatelessComponent<DeprecationHealthProps> = ({ 
 
   return (
     <EuiToolTip content={tooltip}>
-      <EuiBadge color={color}>{`${numHighest} ${highestLevel}`}</EuiBadge>
+      <EuiBadge color={color}>{`${single ? '' : numHighest} ${highestLevel}`}</EuiBadge>
     </EuiToolTip>
   );
 };

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/health.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/health.tsx
@@ -6,10 +6,10 @@
 
 import React, { StatelessComponent } from 'react';
 
-import { EuiHealth } from '@elastic/eui';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
 
 import { DeprecationInfo } from 'src/core_plugins/elasticsearch';
-import { COLOR_MAP, LEVEL_MAP, REVERSE_LEVEL_MAP } from './constants';
+import { ACTION_MAP, COLOR_MAP, LEVEL_MAP, REVERSE_LEVEL_MAP } from './constants';
 
 interface DeprecationHealthProps {
   deprecations: DeprecationInfo[];
@@ -21,7 +21,7 @@ interface DeprecationHealthProps {
  */
 export const DeprecationHealth: StatelessComponent<DeprecationHealthProps> = ({ deprecations }) => {
   if (deprecations.length === 0) {
-    return <EuiHealth color="success">No problems</EuiHealth>;
+    return <span />;
   }
 
   const levels = deprecations.map(d => LEVEL_MAP[d.level]);
@@ -29,6 +29,11 @@ export const DeprecationHealth: StatelessComponent<DeprecationHealthProps> = ({ 
   const highestLevel = REVERSE_LEVEL_MAP[highest];
   const numHighest = deprecations.filter(d => d.level === highestLevel).length;
   const color = COLOR_MAP[highestLevel];
+  const tooltip = ACTION_MAP[highestLevel];
 
-  return <EuiHealth color={color}>{`${numHighest} ${highestLevel}`}</EuiHealth>;
+  return (
+    <EuiToolTip content={tooltip}>
+      <EuiBadge color={color}>{`${numHighest} ${highestLevel}`}</EuiBadge>
+    </EuiToolTip>
+  );
 };

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/index_table.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/checkup/index_table.tsx
@@ -63,7 +63,6 @@ export class IndexDeprecationTable extends React.Component<
         sorting={sorting}
         pagination={pagination}
         onChange={this.onTableChange}
-        show
       />
     );
   }

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/deprecation_logging_toggle.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/deprecation_logging_toggle.tsx
@@ -7,7 +7,7 @@
 import axios from 'axios';
 import React from 'react';
 
-import { EuiFlexGroup, EuiFlexItem, EuiHealth, EuiSwitch, EuiText } from '@elastic/eui';
+import { EuiSwitch } from '@elastic/eui';
 
 import chrome from 'ui/chrome';
 import { LoadingState } from '../checkup/types';
@@ -34,21 +34,12 @@ export class DeprecationLoggingToggle extends React.Component<{}, DeprecationLog
     const { loggingEnabled, loadingState } = this.state;
 
     return (
-      <EuiFlexGroup>
-        <EuiFlexItem grow>
-          <div>
-            <EuiSwitch
-              label="Deprecation Logging"
-              checked={loggingEnabled}
-              onChange={this.toggleLogging}
-              disabled={
-                loadingState === LoadingState.Loading || loadingState === LoadingState.Error
-              }
-            />
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>{this.renderLoggingState()}</EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiSwitch
+        label={this.renderLoggingState()}
+        checked={loggingEnabled}
+        onChange={this.toggleLogging}
+        disabled={loadingState === LoadingState.Loading || loadingState === LoadingState.Error}
+      />
     );
   }
 
@@ -56,13 +47,13 @@ export class DeprecationLoggingToggle extends React.Component<{}, DeprecationLog
     const { loggingEnabled, loadingState } = this.state;
 
     if (loadingState === LoadingState.Error) {
-      return <EuiText color="danger">Could not load logging state.</EuiText>;
+      return 'Could not load logging state';
     } else if (loggingEnabled === undefined) {
-      return null;
+      return null; // TODO: Something better to put here than nothing?
     } else if (loggingEnabled) {
-      return <EuiHealth color="success">Enabled</EuiHealth>;
+      return 'On';
     } else {
-      return <EuiHealth color="danger">Disabled</EuiHealth>;
+      return 'Off';
     }
   }
 

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/index.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/index.tsx
@@ -8,6 +8,9 @@ import React, { Fragment } from 'react';
 
 import {
   EuiCallOut,
+  EuiDescribedFormGroup,
+  EuiFormRow,
+  EuiHorizontalRule,
   EuiLink,
   EuiPageContent,
   EuiPageContentBody,
@@ -45,7 +48,7 @@ export class OverviewTab extends React.Component {
               </p>
             </EuiCallOut>
             <EuiSpacer />
-            <EuiText>
+            <EuiText grow={false}>
               <p>
                 Read more about important changes in the{' '}
                 <EuiLink
@@ -58,15 +61,30 @@ export class OverviewTab extends React.Component {
                 nodes, and indices and find out about any known problems that need to be addressed
                 before upgrading.
               </p>
-              <h2>Deprecation Logging</h2>
-              <p>
-                Elasticsearch comes with a deprecation logger which will log a message whenever
-                deprecated functionality is used. Enable or disable deprecation logging on your
-                cluster here. This is enabled by default, beginning in Elasticsearch 5.0.
-              </p>
             </EuiText>
-            <EuiSpacer />
-            <DeprecationLoggingToggle />
+
+            <EuiHorizontalRule />
+
+            <EuiDescribedFormGroup
+              idAria="deprecation-logging"
+              title={<h3>Deprecation logging</h3>}
+              titleSize="xxs"
+              fullWidth
+              description={
+                <Fragment>
+                  Elasticsearch comes with a deprecation logger which will log a message whenever
+                  deprecated functionality is used. Enable or disable deprecation logging on your
+                  cluster here. This is enabled by default, beginning in Elasticsearch 5.0.
+                </Fragment>
+              }
+            >
+              <EuiFormRow
+                label="Enable deprecation logging?"
+                describedByIds={['deprecation-logging']}
+              >
+                <DeprecationLoggingToggle />
+              </EuiFormRow>
+            </EuiDescribedFormGroup>
           </EuiPageContentBody>
         </EuiPageContent>
       </Fragment>

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/index.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/index.tsx
@@ -6,17 +6,20 @@
 
 import React, { Fragment } from 'react';
 
-import { EuiCallOut, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiLink,
+  EuiPageContent,
+  EuiPageContentBody,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 import { DeprecationLoggingToggle } from './deprecation_logging_toggle';
 
 export class OverviewTab extends React.Component {
   public render() {
     return (
       <Fragment>
-        <EuiSpacer />
-        <EuiTitle>
-          <h3>Overview</h3>
-        </EuiTitle>
         <EuiSpacer />
         <EuiText>
           <p>
@@ -25,41 +28,47 @@ export class OverviewTab extends React.Component {
           </p>
         </EuiText>
         <EuiSpacer />
-        <EuiCallOut title="Backup your indices now!" color="warning" iconType="help">
-          <p>
-            Before starting your upgrade and before using these tools, backup your data using the{' '}
-            <EuiLink
-              href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"
-              target="_blank"
-            >
-              snapshot/restore
-            </EuiLink>{' '}
-            API.
-          </p>
-        </EuiCallOut>
-        <EuiSpacer />
-        <EuiText>
-          <p>
-            Read more about important changes in the{' '}
-            <EuiLink
-              href="https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html"
-              target="_blank"
-            >
-              Breaking Changes
-            </EuiLink>{' '}
-            documentation online. Use this tool to run a series of checks on your cluster, nodes,
-            and indices and find out about any known problems that need to be addressed before
-            upgrading.
-          </p>
-          <h4>Deprecation Logging</h4>
-          <p>
-            Elasticsearch comes with a deprecation logger which will log a message whenever
-            deprecated functionality is used. Enable or disable deprecation logging on your cluster
-            here. This is enabled by default, beginning in Elasticsearch 5.0.
-          </p>
-        </EuiText>
-        <EuiSpacer />
-        <DeprecationLoggingToggle />
+
+        <EuiPageContent>
+          <EuiPageContentBody>
+            <EuiCallOut title="Backup your indices now!" color="warning" iconType="help">
+              <p>
+                Before starting your upgrade and before using these tools, backup your data using
+                the{' '}
+                <EuiLink
+                  href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"
+                  target="_blank"
+                >
+                  snapshot/restore
+                </EuiLink>{' '}
+                API.
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+            <EuiText>
+              <p>
+                Read more about important changes in the{' '}
+                <EuiLink
+                  href="https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html"
+                  target="_blank"
+                >
+                  Breaking Changes
+                </EuiLink>{' '}
+                documentation online. Use this tool to run a series of checks on your cluster,
+                nodes, and indices and find out about any known problems that need to be addressed
+                before upgrading.
+              </p>
+              <h2>Deprecation Logging</h2>
+              <p>
+                Elasticsearch comes with a deprecation logger which will log a message whenever
+                deprecated functionality is used. Enable or disable deprecation logging on your
+                cluster here. This is enabled by default, beginning in Elasticsearch 5.0.
+              </p>
+            </EuiText>
+            <EuiSpacer />
+            <DeprecationLoggingToggle />
+          </EuiPageContentBody>
+        </EuiPageContent>
       </Fragment>
     );
   }

--- a/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/index.tsx
+++ b/x-pack/plugins/upgrade_checkup/public/components/tabs/overview/index.tsx
@@ -9,12 +9,16 @@ import React, { Fragment } from 'react';
 import {
   EuiCallOut,
   EuiDescribedFormGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiFormRow,
   EuiHorizontalRule,
   EuiLink,
   EuiPageContent,
   EuiPageContentBody,
+  EuiPanel,
   EuiSpacer,
+  EuiStat,
   EuiText,
 } from '@elastic/eui';
 import { DeprecationLoggingToggle } from './deprecation_logging_toggle';
@@ -30,6 +34,43 @@ export class OverviewTab extends React.Component {
             <strong>Elasticsearch 6.x</strong> to <strong>Elasticsearch 7</strong>.
           </p>
         </EuiText>
+
+        <EuiSpacer />
+
+        {/* TODO: Hook this up with actual numbers and links to tabs */}
+        <EuiFlexGroup responsive={false}>
+          <EuiFlexItem style={{ maxWidth: 220 }}>
+            <EuiPanel>
+              <EuiStat title="2" description="Cluster issues">
+                <EuiLink>View all</EuiLink>
+              </EuiStat>
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem style={{ maxWidth: 220 }}>
+            <EuiPanel>
+              <EuiStat title="14" description="Index issues">
+                <EuiLink>View all</EuiLink>
+              </EuiStat>
+            </EuiPanel>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer />
+
+        {/* TODO: Only show this if there are 0 issues (also don't show the above) */}
+        <EuiPanel>
+          <EuiText grow={false}>
+            <h2>The coast is clear!</h2>
+            <p>
+              There are no issues with either your cluster or your indices. You may proceed with the
+              upgrade.
+            </p>
+            <p>
+              If you're on cloud, <EuiLink>go here</EuiLink>, otherwise <EuiLink>go here</EuiLink>.
+            </p>
+          </EuiText>
+        </EuiPanel>
+
         <EuiSpacer />
 
         <EuiPageContent>
@@ -57,9 +98,11 @@ export class OverviewTab extends React.Component {
                 >
                   Breaking Changes
                 </EuiLink>{' '}
-                documentation online. Use this tool to run a series of checks on your cluster,
-                nodes, and indices and find out about any known problems that need to be addressed
-                before upgrading.
+                documentation online.
+              </p>
+              <p>
+                Use this tool to run a series of checks on your cluster, nodes, and indices and find
+                out about any known problems that need to be addressed before upgrading.
               </p>
             </EuiText>
 

--- a/x-pack/plugins/upgrade_checkup/public/index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/index.scss
@@ -7,27 +7,27 @@ upgrade-checkup {
   background-color: $euiColorLightestShade;
 }
 
-.upgrade-checkup__deprecation-cell {
-  border: 1px solid #D9D9D9;
-  padding: 10px;
+// .upgrade-checkup__deprecation-cell {
+//   border: 1px solid #D9D9D9;
+//   padding: 10px;
 
-  & + & {
-    border-top: 0;
-    border-radius: 0
-  }
+//   & + & {
+//     border-top: 0;
+//     border-radius: 0
+//   }
 
-  &:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-  }
-  &:last-child {
-    @include euiBottomShadowSmall;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    margin-bottom: 10px;
-  }
-}
+//   &:first-child {
+//     border-top-left-radius: 4px;
+//     border-top-right-radius: 4px;
+//   }
+//   &:last-child {
+//     @include euiBottomShadowSmall;
+//     border-bottom-left-radius: 4px;
+//     border-bottom-right-radius: 4px;
+//     margin-bottom: 10px;
+//   }
+// }
 
-.upgrade-checkup__index-deprecation-header {
-  margin-top: 10px;
-}
+// .upgrade-checkup__index-deprecation-header {
+//   margin-top: 10px;
+// }

--- a/x-pack/plugins/upgrade_checkup/public/index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/index.scss
@@ -1,5 +1,10 @@
 @import 'ui/public/styles/_styling_constants';
 
+upgrade-checkup {
+  background-color: $euiColorLightestShade;
+  flex-grow: 1;
+}
+
 .upgrade-checkup__deprecation-cell {
   border: 1px solid #D9D9D9;
   padding: 10px;

--- a/x-pack/plugins/upgrade_checkup/public/index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/index.scss
@@ -1,33 +1,4 @@
 @import 'ui/public/styles/_styling_constants';
 
-@import './components/tabs/checkup/index';
-
-upgrade-checkup {
-  flex-grow: 1;
-  background-color: $euiColorLightestShade;
-}
-
-// .upgrade-checkup__deprecation-cell {
-//   border: 1px solid #D9D9D9;
-//   padding: 10px;
-
-//   & + & {
-//     border-top: 0;
-//     border-radius: 0
-//   }
-
-//   &:first-child {
-//     border-top-left-radius: 4px;
-//     border-top-right-radius: 4px;
-//   }
-//   &:last-child {
-//     @include euiBottomShadowSmall;
-//     border-bottom-left-radius: 4px;
-//     border-bottom-right-radius: 4px;
-//     margin-bottom: 10px;
-//   }
-// }
-
-// .upgrade-checkup__index-deprecation-header {
-//   margin-top: 10px;
-// }
+@import './app';
+@import './components/index';

--- a/x-pack/plugins/upgrade_checkup/public/index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/index.scss
@@ -1,8 +1,8 @@
 @import 'ui/public/styles/_styling_constants';
 
 upgrade-checkup {
-  background-color: $euiColorLightestShade;
   flex-grow: 1;
+  background-color: $euiColorLightestShade;
 }
 
 .upgrade-checkup__deprecation-cell {

--- a/x-pack/plugins/upgrade_checkup/public/index.scss
+++ b/x-pack/plugins/upgrade_checkup/public/index.scss
@@ -1,5 +1,7 @@
 @import 'ui/public/styles/_styling_constants';
 
+@import './components/tabs/checkup/index';
+
 upgrade-checkup {
   flex-grow: 1;
   background-color: $euiColorLightestShade;

--- a/x-pack/plugins/upgrade_checkup/server/lib/__fixtures__/fake_deprecations.json
+++ b/x-pack/plugins/upgrade_checkup/server/lib/__fixtures__/fake_deprecations.json
@@ -1,5 +1,18 @@
 {
-  "cluster_settings": [],
+  "cluster_settings": [
+    {
+      "level": "info",
+      "message": "Template patterns are no longer using `template` field, but `index_patterns` instead",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_indices_changes.html#_index_templates_use_literal_index_patterns_literal_instead_of_literal_template_literal",
+      "details": "templates using `template` field: security_audit_log,watches,.monitoring-alerts,triggered_watches,.ml-anomalies-,.ml-notifications,.ml-meta,.monitoring-kibana,.monitoring-es,.monitoring-logstash,.watch-history-6,.ml-state,security-index-template"
+    },
+    {
+      "level": "info",
+      "message": "one or more templates use deprecated mapping settings",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_indices_changes.html",
+      "details": "{.monitoring-logstash=[Coercion of boolean fields], .monitoring-es=[Coercion of boolean fields], .ml-anomalies-=[Coercion of boolean fields], .watch-history-6=[Coercion of boolean fields], .monitoring-kibana=[Coercion of boolean fields], security-index-template=[Coercion of boolean fields]}"
+    }
+  ],
   "node_settings": [],
   "index_settings": {
     ".monitoring-es-6-2018.11.07": [

--- a/x-pack/plugins/upgrade_checkup/server/lib/__fixtures__/fake_deprecations.json
+++ b/x-pack/plugins/upgrade_checkup/server/lib/__fixtures__/fake_deprecations.json
@@ -1,18 +1,5 @@
 {
-  "cluster_settings": [
-    {
-      "level": "info",
-      "message": "Template patterns are no longer using `template` field, but `index_patterns` instead",
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_indices_changes.html#_index_templates_use_literal_index_patterns_literal_instead_of_literal_template_literal",
-      "details": "templates using `template` field: security_audit_log,watches,.monitoring-alerts,triggered_watches,.ml-anomalies-,.ml-notifications,.ml-meta,.monitoring-kibana,.monitoring-es,.monitoring-logstash,.watch-history-6,.ml-state,security-index-template"
-    },
-    {
-      "level": "info",
-      "message": "one or more templates use deprecated mapping settings",
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_indices_changes.html",
-      "details": "{.monitoring-logstash=[Coercion of boolean fields], .monitoring-es=[Coercion of boolean fields], .ml-anomalies-=[Coercion of boolean fields], .watch-history-6=[Coercion of boolean fields], .monitoring-kibana=[Coercion of boolean fields], security-index-template=[Coercion of boolean fields]}"
-    }
-  ],
+  "cluster_settings": [],
   "node_settings": [],
   "index_settings": {
     ".monitoring-es-6-2018.11.07": [


### PR DESCRIPTION
> I apologize for any bad JavaScript, hopefully, you can understand the intent and do a clean up.

Here were a few items that still need to finalized:

### 1. Overview stats & all clear message

(Gail is working on text changes)
<img src="https://d.pr/free/i/IaSg8K+" />

### 2. All clear message per deprecation tabs

I added an all clear message if there are no issues in these tabs, however, it's not quite hooked up right because it will show if you remove all severity types via the filters.

<img src="https://d.pr/free/i/dteEfN+" />

### 3. Extra list functionality

I added a filter bar and expand/collapse buttons to the top of the lists that need to actually be hooked up (if possible).

<img src="https://d.pr/free/i/80Ywzk+" />

### 4. Action buttons

I couldn't move the action buttons so I added a placeholder location "Action button here".

<img width="974" alt="screen shot 2018-11-29 at 13 24 09 pm" src="https://user-images.githubusercontent.com/549577/49242946-18d78e00-f3da-11e8-8e7b-5687d4f7bc1e.png">


### 5. Severity indicators

It looked like each severity had it's own description that didn't change base on the issue type, so instead of displaying this description repetitively, I moved the description to be a tooltip around the badge.

Also, since only the 'by index' grouping actually has multiple issues and severities, I removed the numbers from the other groupings. However, I think you can go ahead and list all severities when grouping by index instead of just showing the highest severity.

<img src="https://d.pr/free/i/Ap15BM+" />

## A couple questions:

a. Are you thinking of adding any pagination to the list of issues?
b. Is there any way to format the details? It's really hard to read as a long string
c. Can the details be really long? Should we consider truncating those? 

## I still need to:

- Style the all clear states, they're good as placeholders for now
- Browser check
